### PR TITLE
Remove webpack specific code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,27 +41,3 @@ module.exports.findComponents = function(dirs, componentName) {
     dirs.map(walk);
     return components;
 };
-
-
-module.exports.riotifyComponent = function(loader, location) {
-        var files = fs.readdirSync(location);
-        var componentName = path.basename(location);
-
-        if(files.indexOf('index.js') == -1) {
-            loader.emitError("component at "+location+" requires an index.js file.");
-        }
-
-        if(files.indexOf('index.html') == -1) {
-            loader.emitError("component at "+location+" requires an index.html file.");
-        }
-
-        if(files.indexOf('test.js') == -1) {
-            loader.emitWarning("component at "+location+" missing a test.js file.");
-        }
-        var js = path.resolve(location, 'index.js');
-        var template = path.resolve(location, 'index.html');
-        loader.addDependency(js);
-        loader.addDependency(template);
-        return "riot.tag('"+componentName+"', `"+fs.readFileSync(template)+"`, require('"+js+"'));";
-};
-


### PR DESCRIPTION
From the looks of things this code only exists to enable support for
[`rukus-loader`](https://github.com/iflix-letsplay/rukus-loader/). I'd be inclined to move this into that module instead.

This migration has already been conducted over on: 
- https://github.com/iflix-letsplay/rukus-loader/pull/2
