### PR TITLE
remove warning when test.js does not exists in component path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,9 +55,6 @@ module.exports.riotifyComponent = function(loader, location) {
             loader.emitError("component at "+location+" requires an index.html file.");
         }
 
-        if(files.indexOf('test.js') == -1) {
-            loader.emitWarning("component at "+location+" missing a test.js file.");
-        }
         var js = path.resolve(location, 'index.js');
         var template = path.resolve(location, 'index.html');
         loader.addDependency(js);


### PR DESCRIPTION
Not every component needs to be tested
